### PR TITLE
修正 _config.yml 中一处说明错误

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,7 +36,7 @@ theme-color: 'default'  # pink or default
 # Post header background patterns (when the post no cover): circuitBoard, overlappingCircles, food, glamorous, ticTacToe, seaOfClouds
 postPatterns: 'circuitBoard'
 
-# SNS settings 配置社交网站url: weibo, zhihu, twitter, instagrame, juejin, github, douban, facebook, dribble, uicn, jianshu, medium, linkedin
+# SNS settings 配置社交网站url: weibo, zhihu, twitter, instagram, juejin, github, douban, facebook, dribble, uicn, jianshu, medium, linkedin
 sns:
   weibo: '//weibo.com/lovecolcol'
   juejin: '//juejin.im/user/57a6f434165abd006159b4cc'


### PR DESCRIPTION
_config.yml  中 instagram 在说明中打成了  instagrame，凑巧我复制粘贴到了下面的 sns 中，导致图标不显示