### PR TITLE
Update gems -> plugins

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -61,4 +61,4 @@ kramdown:
 RSS: false
 
 # Plugins
-gems: [jekyll-paginate]
+plugins: [jekyll-paginate]


### PR DESCRIPTION
Update gems -> plugins in _config.yml per Jekyll deprecation warning:

`Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.`