### PR TITLE
Fix baseurl problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ title: '廖柯宇的独立博客' # 你的博客网站标题
 description: '很高兴能在这里与你分享我对技术和生活的思考。' # 站点描述
 keyword: '廖柯宇, 廖柯宇的独立博客, 前端, 设计' # 网站关键词
 url: 'http://liaokeyu.com' # 站点url 
-baseurl: '/'
+baseurl: ''
  
 # Build settings 
 paginate: 6 # 一页放几篇文章

--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,9 @@ title: '廖柯宇的独立博客'
 description: '昵称悟空，千禧一代，前端开发者/伪极客/灵魂摄影师，热爱技术&设计。很高兴能在这里与你分享我对技术和生活的思考。'
 keyword: '廖柯宇, 廖柯宇的独立博客, 廖柯宇的博客, 前端, 前端开发, 前端博客, javascript, vuejs, nodejs, 设计'
 url: 'http://liaokeyu.com' # your host
-baseurl: '/'
+
+# if you don't need baseurl, you should leave this value blank.
+baseurl: ''
 
 # Navigation links
 nav:

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,6 +1,6 @@
 <header class="g-header">
     <div class="g-logo">
-        <a href="{{ site.baseurl }}"></a>
+      <a href="{{ "/" | relative_url }}"></a>
     </div>
     <i id="menu-toggle" class="iconfont icon-menu"></i>
     <nav class="g-nav">

--- a/_includes/pageNav.html
+++ b/_includes/pageNav.html
@@ -1,11 +1,11 @@
 <nav class="pagination">
     <input type="hidden" id="total_pages" value="{{ paginator.total_pages }}">
     <input type="hidden" id="current_pages" value="{{ paginator.page }}">
-    <input type="hidden" id="base_url" value="{{ site.baseurl }}">
+    <input type="hidden" id="base_url" value="{{ "/" | relative_url }}">
     <div class="page-links">
         {% if paginator.previous_page %}
             {% if paginator.previous_page == 1 %}
-            <a href="{{ site.baseurl }}" class="page-link" title="Previous Page">&laquo;</a>
+            <a href="{{ "/" | relative_url }}" class="page-link" title="Previous Page">&laquo;</a>
             {% else %}
             <a href="/page{{ paginator.previous_page }}/" class="page-link" title="Previous Page">&laquo;</a>
             {% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,7 @@
     <input id="nm-switch" type="hidden" value="{{ site.nightMode }}">
     {{ content }}
     <script src="https://cdn.staticfile.org/jquery/3.2.1/jquery.min.js"></script>
-    <script src="{{ site.baseurl }}assets/js/prism.js"></script>
-    <script src="{{ site.baseurl }}assets/js/index.min.js"></script>
+    <script src="{{ "assets/js/prism.js" | prepend: site.baseurl }}"></script>
+    <script src="{{ "assets/js/index.min.js" | prepend: site.baseurl }}"></script>
 </body>
 </html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -12,9 +12,9 @@
 <header class="g-banner post-header {{ site.postPatterns | prepend: 'post-pattern-' }} {{ site.theme-color | prepend: 'bgcolor-' }} {% unless page.cover %}post-no-cover{% endunless %}" data-theme="{{ site.theme-color }}">
     <div class="post-wrapper">
         <div class="post-tags">
-            {% if page.tags.size > 0 %} 
+            {% if page.tags.size > 0 %}
             {% for tag in page.tags  %}
-            <a href="/tags#{{ tag }}" class="post-tag">{{ tag }}</a>
+            <a href="{{ "tags#" | append: tag | absolute_url }}" class="post-tag">{{ tag }}</a>
             {% endfor %}
             {% endif %}
         </div>
@@ -47,7 +47,7 @@
 <section class="author-detail">
     <section class="post-footer-item author-card">
         <div class="avatar">
-            <img src="/{{ site.avatar }}" alt="">
+            <img src="{{ site.avatar | absolute_url }}" alt="">
         </div>
         <div class="author-name" rel="author">{{ site.author }}</div>
         <div class="bio">
@@ -79,7 +79,7 @@
             {% endif %}
         </div>
         {% endif %}
-        {% if page.previous.url %} 
+        {% if page.previous.url %}
         <div class="read-next-item">
             <a href="{{ page.previous.url }}" class="read-next-link"></a>
             <section>
@@ -130,7 +130,7 @@ s.setAttribute('data-timestamp', +new Date());
 </script>
 <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
 <script src="https://cdn.staticfile.org/jquery/3.2.1/jquery.min.js"></script>
-<script src="/assets/js/prism.js"></script>
-<script src="/assets/js/index.min.js"></script>
+<script src="{{ "assets/js/prism.js" | pretend: site.baseurl }}"></script>
+<script src="{{ "assets/js/index.min.js" | pretend: site.baseurl }}"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@ description: 或许是最漂亮的Jekyll主题
     <h2>{{ page.home-title }}</h2>
     <h3>{{ page.description }}</h3>
     {% if page.header-img %}
-    <img class="header-img" src="{{ site.baseurl }}{{ page.header-img }}" alt="">
+    <img class="header-img" src="{{ page.header-img | prepend: site.baseurl }}" alt="">
     {% endif %}
 </div>
 
@@ -57,7 +57,7 @@ description: 或许是最漂亮的Jekyll主题
         <div class="g-sidebar">
             <section class="author-card">
                 <div class="avatar">
-                    <img src="{{ site.baseurl }}{{ site.avatar }}" alt="">
+                    <img src="{{ site.avatar | prepend: site.baseurl }}" alt="">
                 </div>
                 <div class="author-name" rel="author">{{ site.author }}</div>
                 <div class="bio">
@@ -82,7 +82,7 @@ description: 或许是最漂亮的Jekyll主题
                     {% if forloop.index > site.recommend-condition-size %}
                         {% break %}
                     {% endif %}
-                <a href="{{ site.baseurl }}tags.html#{{ tag[0] }}" class="tag">{{ tag[0]}}</a>
+                    <a href="{{ "tags.html#" | append: tag[0] | prepend: site.baseurl }}" class="tag">{{ tag[0]}}</a>
                 {% endfor %}
             </section>
             {% endif %}

--- a/index.html
+++ b/index.html
@@ -30,15 +30,15 @@ description: 或许是最漂亮的Jekyll主题
                     {% if post.subtitle %}
                     <h3 class="post-subtitle">{{ post.subtitle }}</h3>
                     {% endif %}
-                    {% if post.subtitle.size==0 or post.subtitle==nil %} 
+                    {% if post.subtitle.size==0 or post.subtitle==nil %}
                     <p class="post-excerpt">{{ post.excerpt | strip_html | strip_newlines | truncate: 126}}</p>
                     {% endif %}
                 </section>
                 <footer class="post-meta">
                     <div class="post-tags">
-                        {% if post.tags.size > 0 %} 
+                        {% if post.tags.size > 0 %}
                             {% for tag in post.tags  %}
-                        <a href="{{ site.baseurl }}tags.html#{{ tag }}" class="post-tag">{{ tag }}</a>
+                            <a href={{ "tags.html#" | append: tag | pretend: site.baseurl}} class="post-tag">{{ tag }}</a>
                             {% endfor %}
                         {% endif %}
                     </div>
@@ -95,9 +95,9 @@ description: 或许是最漂亮的Jekyll主题
             <div class="search_result"></div>
         </div>
         {% endif %}
-        
+
     </aside>
-    
+
 </main>
 
 {% include footer.html %}


### PR DESCRIPTION
Fix #18 
簡單說明一下問題
在 deploy 的時候
baseurl 的值要是 "/" 就會變成 null
解決的方法從
`{{ site.baseurl }}` 改成 `{{ "/" | relative_url }}`
新增說明要是沒有使用 baseurl 要把值流空
並修正了一些寫法用 filter 取代字串的串接
[relative_url 說明](https://jekyllrb.com/docs/templates/)