### PR TITLE
修正：删除一个多出来的 </div>

### DIFF
--- a/tags.html
+++ b/tags.html
@@ -26,8 +26,6 @@ layout: default
             <a class="tag-post" href="{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a>
             {% endfor %}
         </li>
-        
-        </div>
         {% endfor%}
     </ul>
 </main>


### PR DESCRIPTION
tags.html 标签列表中多了一个 `</div>`，导致从第二个标签开始样式异常。