### PR TITLE
fix disqus

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -135,7 +135,7 @@
     */
     (function() { // DON'T EDIT BELOW THIS LINE
       var d = document, s = d.createElement('script');
-      s.src = 'https://liaokeyu.disqus.com/embed.js';
+      s.src = '{{ site.comments.disqus_url }}';
       s.setAttribute('data-timestamp', +new Date());
       (d.head || d.body).appendChild(s);
     })();


### PR DESCRIPTION
把disqus在post.html中写死的变量修改为全局变量，解决了在_config.yml中修改disqus_url后仍然显示的是主题原作者的disqus